### PR TITLE
fix: indentation issue in pure preset

### DIFF
--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -42,5 +42,5 @@ format = "[$duration]($style) "
 style = "yellow"
 
 [python]
-format = "[$virtualenv]($style) "
+format = "[($virtualenv )]($style)"
 style = "bright-black"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR, inspired by `no-empty-icons` preset, includes the trailing whitespace in the venv name itself. So if the venv name is not available, the trailing whitespace will not be either.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a python module is detected but venv is not active, only the trailing whitespace is displayer since the venv name is not available.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**
